### PR TITLE
feat(SwaggerDoc):增加参数其他信息展示

### DIFF
--- a/Sample/Models/CreateOrderRequest.cs
+++ b/Sample/Models/CreateOrderRequest.cs
@@ -10,19 +10,21 @@ public class CreateOrderRequest
     /// <summary>
     /// 商品ID
     /// </summary>
+    [Range(1, int.MaxValue, ErrorMessage = "范围为1-int32.max")]
     public int GoodsId { get; set; }
-    
+
     /// <summary>
     /// 商品名称
     /// </summary>
     [Required]
+    [MaxLength(256, ErrorMessage = "最大长度为256")]
     public string GoodsName { get; set; }
-    
+
     /// <summary>
     /// 商品数量
     /// </summary>
     public int GoodsNum { get; set; }
-    
+
     /// <summary>
     /// 订单类型
     /// </summary>

--- a/Sample/Models/CreateOrderResponse.cs
+++ b/Sample/Models/CreateOrderResponse.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Sample.Models;
 
 /// <summary>
@@ -8,13 +10,16 @@ public class CreateOrderResponse
     /// <summary>
     /// 订单号
     /// </summary>
+    [MinLength(1, ErrorMessage = "最小长度为1")]
+    [MaxLength(64, ErrorMessage = "最大长度为64")]
+    [RegularExpression("^[a-zA-Z0-9-]+$", ErrorMessage = "只允许包含大小写字母、数字和英文中横线")]
     public string OrderNo { get; set; }
 
     /// <summary>
     /// 支付链接
     /// </summary>
     public string PayUrl { get; set; }
-    
+
     /// <summary>
     /// 支付二维码
     /// </summary>

--- a/Sample/Models/GetOrderListRequest.cs
+++ b/Sample/Models/GetOrderListRequest.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Sample.Models;
 
 /// <summary>
@@ -8,13 +10,16 @@ public class GetOrderListRequest
     /// <summary>
     /// 订单号
     /// </summary>
+    [MinLength(1, ErrorMessage = "最小长度为1")]
+    [MaxLength(64, ErrorMessage = "最大长度为64")]
+    [RegularExpression("^[a-zA-Z0-9-]+$", ErrorMessage = "只允许包含大小写字母、数字和英文中横线")]
     public string OrderNo { get; set; }
-    
+
     /// <summary>
     /// 订单类型
     /// </summary>
     public OrderType OrderType { get; set; }
-    
+
     /// <summary>
     /// 订单状态
     /// </summary>

--- a/SwaggerDoc/Models/OtherInfo.cs
+++ b/SwaggerDoc/Models/OtherInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SwaggerDoc.Models
+{
+    /// <summary>
+    /// 其他信息
+    /// </summary>
+    public class OtherInfo
+    {
+        /// <summary>
+        /// 最小长度
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? 最小长度 { get; set; }
+        /// <summary>
+        /// 最大长度
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? 最大长度 { get; set; }
+        /// <summary>
+        /// 最小值
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public decimal? 最小值 { get; set; }
+        /// <summary>
+        /// 最大值
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public decimal? 最大值 { get; set; }
+        /// <summary>
+        /// 格式校验
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string 格式校验 { get; set; }
+    }
+}

--- a/SwaggerDoc/Models/RequestModelInfo.cs
+++ b/SwaggerDoc/Models/RequestModelInfo.cs
@@ -24,5 +24,10 @@
         /// 是否必传
         /// </summary>
         public bool 是否必传 { get; set; }
+
+        /// <summary>
+        /// 其他信息
+        /// </summary>
+        public OtherInfo 其他信息 { get; set; }
     }
 }

--- a/SwaggerDoc/Models/ResponseModelInfo.cs
+++ b/SwaggerDoc/Models/ResponseModelInfo.cs
@@ -19,5 +19,10 @@
         /// 可空类型
         /// </summary>
         public bool 可空类型 { get; set; }
+
+        /// <summary>
+        /// 其他信息
+        /// </summary>
+        public OtherInfo 其他信息 { get; set; }
     }
 }

--- a/SwaggerDoc/SwaggerDocGenerator.cs
+++ b/SwaggerDoc/SwaggerDocGenerator.cs
@@ -135,18 +135,35 @@ namespace SwaggerDoc
         {
             string str = null;
             var isFirst = true;
-            var queryTitle = "|参数名称|参数类型|参数位置|描述|".NewLine();
-            queryTitle += "|:----:|:----:|:----:|:----:|".NewLine();
+            var queryTitle = "|参数名称|参数类型|参数位置|描述|其他信息|".NewLine();
+            queryTitle += "|:----:|:----:|:----:|:----:|:----:|".NewLine();
             foreach (var parameter in apiParameters)
             {
                 var queryStr =
-                    $"|{parameter.Name}|{parameter.Schema.Type ?? parameter.Schema.Reference.Id}|{parameter.In}|{parameter.Description}|"
+                    $"|{parameter.Name}|{parameter.Schema.Type ?? parameter.Schema.Reference.Id}|{parameter.In}|{parameter.Description}|{GetParameterOtherInfo(parameter)}|"
                         .NewLine();
                 str += isFirst ? $"{queryTitle}{queryStr}" : queryStr;
                 isFirst = false;
             }
 
             return str;
+        }
+
+        /// <summary>
+        /// 获取参数其他信息
+        /// </summary>
+        /// <param name="parameter">参数</param>
+        /// <returns>参数其他信息</returns>
+        private static string GetParameterOtherInfo(OpenApiParameter parameter)
+        {
+            var otherInfoStr = string.Empty;
+            otherInfoStr += parameter.Required ? $"是否必传：`{parameter.Required.ToString()}`".Br() : string.Empty;
+            otherInfoStr += parameter.Schema.MinLength.HasValue ? $"最小长度：`{parameter.Schema.MinLength.Value}`".Br() : string.Empty;
+            otherInfoStr += parameter.Schema.MaxLength.HasValue ? $"最大长度：`{parameter.Schema.MaxLength.Value}`".Br() : string.Empty;
+            otherInfoStr += parameter.Schema.Minimum.HasValue ? $"最小值：`{parameter.Schema.Minimum.Value}`".Br() : string.Empty;
+            otherInfoStr += parameter.Schema.Maximum.HasValue ? $"最大值：`{parameter.Schema.Maximum.Value}`".Br() : string.Empty;
+            otherInfoStr += !string.IsNullOrWhiteSpace(parameter.Schema.Pattern) ? $"格式校验：`{parameter.Schema.Pattern}`" : string.Empty;
+            return otherInfoStr;
         }
 
         /// <summary>
@@ -388,7 +405,15 @@ namespace SwaggerDoc
                         参数类型 = obj,
                         描述 = value.Description,
                         是否必传 = schema.Required.Any(x => x == s),
-                        可空类型 = value.Nullable
+                        可空类型 = value.Nullable,
+                        其他信息 = new OtherInfo
+                        {
+                            最小长度 = value.MinLength,
+                            最大长度 = value.MaxLength,
+                            格式校验 = value.Pattern,
+                            最小值 = value.Minimum,
+                            最大值 = value.Maximum,
+                        }
                     };
                     properties.Add(s, requestModelInfo);
                 }
@@ -398,7 +423,15 @@ namespace SwaggerDoc
                     {
                         参数类型 = obj,
                         描述 = value.Description,
-                        可空类型 = value.Nullable
+                        可空类型 = value.Nullable,
+                        其他信息 = new OtherInfo
+                        {
+                            最小长度 = value.MinLength,
+                            最大长度 = value.MaxLength,
+                            格式校验 = value.Pattern,
+                            最小值 = value.Minimum,
+                            最大值 = value.Maximum,
+                        }
                     };
                     properties.Add(s, responseModelInfo);
                 }


### PR DESCRIPTION
- 在 Swagger 文档中添加参数的其他信息，如最小长度、最大长度、最小值、最大值和格式校验
- 修改 CreateOrderRequest、CreateOrderResponse 和 GetOrderListRequest 模型，增加相应的属性
- 更新 SwaggerDocGenerator 类，增加 GetParameterOtherInfo 方法获取参数其他信息
- 在 RequestModelInfo 和 ResponseModelInfo 模型中添加 其他信息 属性

![image](https://github.com/user-attachments/assets/5f9e4c73-765c-414b-8e46-a8ac1cc3cd99)
![image](https://github.com/user-attachments/assets/f50a15a7-4d96-4496-8545-3f7c089f66ab)
